### PR TITLE
Fix org-projectile:capture-for-current-project to be a command

### DIFF
--- a/org-projectile.el
+++ b/org-projectile.el
@@ -457,6 +457,7 @@
 
 ;;;###autoload
 (defun org-projectile:capture-for-current-project (&optional capture-template)
+  (interactive)
   (let ((project-name (projectile-project-name)))
     (if (projectile-project-p)
         (org-projectile:capture-for-project project-name capture-template)


### PR DESCRIPTION
This patch declare org-projectile:capture-for-current-project has a command,
it may therefore be called interactively (via M-x or by entering a key sequence
bound to it).