### PR TITLE
Miscellaneous

### DIFF
--- a/org-projectile.el
+++ b/org-projectile.el
@@ -348,8 +348,11 @@ location of the filepath cache."
 
 (defvar dired-buffers)
 
-(defun org-projectile:capture-for-project (project-name &optional capture-template)
-  (org-capture-set-plist (org-projectile:project-todo-entry nil capture-template))
+(defun org-projectile:capture-for-project
+    (project-name &optional capture-template &rest additional-options)
+  (org-capture-set-plist
+   (apply #'org-projectile:project-todo-entry
+          nil capture-template nil additional-options))
   ;; TODO: super gross that this had to be copied from org-capture,
   ;; Unfortunately, it does not seem to be possible to call into org-capture
   ;; because it makes assumptions that make it impossible to set things up
@@ -522,25 +525,29 @@ as the capture template."
     (user-error "%s" "This command is only available to helm users. Install helm and try again.")))
 
 ;;;###autoload
-(defun org-projectile:project-todo-completing-read (&optional capture-template)
+(defun org-projectile:project-todo-completing-read
+    (&optional capture-template &rest additional-options)
   "Select a project using a `projectile-completing-read' and record a TODO.
 
 If CAPTURE-TEMPLATE is provided use it as the capture template for the TODO."
   (interactive)
-  (org-projectile:capture-for-project
+  (apply
+   #'org-projectile:capture-for-project
    (projectile-completing-read "Record TODO for project: "
                                (org-projectile:known-projects))
-   capture-template))
+   capture-template additional-options))
 
 ;;;###autoload
-(defun org-projectile:capture-for-current-project (&optional capture-template)
+(defun org-projectile:capture-for-current-project
+    (&optional capture-template &rest additional-options)
   "Capture a TODO for the current active projectile project.
 
 If CAPTURE-TEMPLATE is provided use it as the capture template for the TODO."
   (interactive)
   (let ((project-name (projectile-project-name)))
     (if (projectile-project-p)
-        (org-projectile:capture-for-project project-name capture-template)
+        (apply #'org-projectile:capture-for-project
+               project-name capture-template additional-options)
       (error (format "%s is not a recognized projectile project." project-name)))))
 
 (provide 'org-projectile)

--- a/org-projectile.el
+++ b/org-projectile.el
@@ -431,7 +431,9 @@ location of the filepath cache."
       (progn
         (goto-char (point-max))
         (or (bolp) (insert "\n"))
-        (insert "* " linked-heading)
+        (let ((org-insert-heading-respect-content t))
+          (org-insert-heading nil nil t))
+        (insert linked-heading)
         (when org-projectile:counts-in-heading (insert " [/]"))))
     (nth 4 (org-heading-components))))
 

--- a/org-projectile.el
+++ b/org-projectile.el
@@ -255,7 +255,7 @@ location of the filepath cache."
     (switch-to-buffer (find-file-noselect filename))
     (funcall org-projectile:project-name-to-location project-name)))
 
-(defun org-projectile:target-subheading-and-return-marker ()
+(defun org-projectile:target-subheading-and-return-marker (&optional for-insert)
   (org-end-of-line)
   (org-projectile:end-of-properties)
   ;; It sucks that this has to be done, but we have to insert a


### PR DESCRIPTION
Sorry for putting all of these in one PR. I hope it is uncontroversial enough.

* https://github.com/IvanMalison/org-projectile/commit/2a6229777bba2457803b090c829a893538596b94 I like to use `:empty-lines 1` in my capture templates, which works fine with org-projectile after `additional-options` was introduced, but the master "project heading" doesn't obey it. Instead, call `org-insert-heading` with `org-insert-heading-respect-content` set to true.

* https://github.com/IvanMalison/org-projectile/commit/89092b518068c20c3f8d08f7f914d620e0e878ee Fixes what appears to be an oversight, but I'm not sure if changes are needed where this function is being called (should it be nil or t?)

* https://github.com/IvanMalison/org-projectile/commit/1d944fe749ff5f37fe355860d286a8985839e47d Allows use of `additional-options` also when using `project-todo-completing-read` and `capture-for-current-project`.