### PR TITLE
Remove org-projectile:path-to-category

### DIFF
--- a/org-projectile.el
+++ b/org-projectile.el
@@ -31,7 +31,6 @@
 (require 'cl-lib)
 (require 'eieio)
 (require 'org-category-capture)
-(require 'pcache)
 (require 'projectile)
 (require 'dash)
 
@@ -81,9 +80,6 @@
   :group 'org-projectile)
 
 
-
-(defvar org-projectile:path-to-category
-  (pcache-repository "org-projectile:path-to-category"))
 
 (defvar org-projectile:target-entry t)
 


### PR DESCRIPTION
This variable isn't used anywhere, and the way `pcache-repository` is
being used throws a warning---so the simplest thing to do would seem to
be to simply remove it (and the dependency on `pcache`).

Resolves IvanMalison/org-projectile#24