### PR TITLE
org-projectile:project-name-to-location-alist: use true names

### DIFF
--- a/org-projectile.el
+++ b/org-projectile.el
@@ -410,7 +410,8 @@ location of the filepath cache."
 (defun org-projectile:project-name-to-location-alist ()
   (cl-loop for project-location in projectile-known-projects
            collect `(,(file-name-nondirectory
-                       (directory-file-name project-location)) .
+                       (directory-file-name
+                        (org-projectile:file-truename project-location))) .
                        ,project-location)))
 
 (defun org-projectile:project-location-from-name (name)


### PR DESCRIPTION
* fixes, e.g.:

  `(org-projectile:capture-for-current-project nil :empty-lines 1)`

  from a subdirectory of a project rooted at `~/` (e.g., from
  `~/foo/bar/`), whose project name would erroneously be `"~"` instead
  of its expansion (its true name--the current user)
