### PR TITLE
Add &allow-other-keys to fix d57062569e59f598fcad1107f463691ec5d07e5f

### DIFF
--- a/org-projectile.el
+++ b/org-projectile.el
@@ -329,7 +329,7 @@
 
 ;;;###autoload
 (cl-defun org-projectile-project-todo-completing-read
-    (&rest additional-options &key capture-template)
+    (&rest additional-options &key capture-template &allow-other-keys)
   "Select a project using a `projectile-completing-read' and record a TODO.
 
 If CAPTURE-TEMPLATE is provided use it as the capture template
@@ -348,7 +348,7 @@ were part of the capture template definition."
 
 ;;;###autoload
 (cl-defun org-projectile-capture-for-current-project
-    (&rest additional-options &key capture-template)
+    (&rest additional-options &key capture-template &allow-other-keys)
   "Capture a TODO for the current active projectile project.
 
 If CAPTURE-TEMPLATE is provided use it as the capture template


### PR DESCRIPTION
Otherwise calling (org-projectile-capture-for-current-project nil) or
(org-projectile-capture-for-current-project :capture-template nil
:some-option 1) results in an error and only
(org-projectile-capture-for-current-project :capture-template nil) works.

See d57062569e59f598fcad1107f463691ec5d07e5f