### PR TITLE
Fix issue #44. Make occ-capture window behaviour same as org-capture

### DIFF
--- a/org-category-capture.el
+++ b/org-category-capture.el
@@ -98,11 +98,11 @@
        (list 'function (lambda ()
                          (occ-capture-goto-marker context))))
       (org-capture-put :target-entry-p (occ-target-entry-p strategy context))
-      (org-capture-place-template))))
+      (org-capture-place-template 't))))
 
 (defun occ-capture-goto-marker (context)
   (let ((marker (occ-get-capture-marker context)))
-    (switch-to-buffer (marker-buffer marker))
+    (set-buffer (marker-buffer marker))
     (goto-char (marker-position marker))))
 
 (defmethod occ-get-capture-marker ((context occ-context))


### PR DESCRIPTION
occ-capture-goto-marker's "switch-to-buffer" call was opening the target buffer in a window,
and the lack of org-capture-place-template's optional argument meant the window-configuration was overridden. 