### PR TITLE
Refactor: remove emacs 24.

### DIFF
--- a/org-category-capture.el
+++ b/org-category-capture.el
@@ -37,14 +37,14 @@
 
 (defclass occ-strategy nil nil)
 
-(defmethod occ-get-categories ((_ occ-strategy)))
+(cl-defmethod occ-get-categories ((_ occ-strategy)))
 
-(defmethod occ-get-todo-files ((_ occ-strategy)))
+(cl-defmethod occ-get-todo-files ((_ occ-strategy)))
 
-(defmethod occ-get-capture-marker ((_ occ-strategy) _context)
+(cl-defmethod occ-get-capture-marker ((_ occ-strategy) _context)
   "Return a marker that corresponds to the capture location for CONTEXT.")
 
-(defmethod occ-target-entry-p ((_ occ-strategy) _context))
+(cl-defmethod occ-target-entry-p ((_ occ-strategy) _context))
 
 (defclass occ-context ()
   ((category :initarg :category)
@@ -52,8 +52,7 @@
    (options :initarg :options)
    (strategy :initarg :strategy)))
 
-;; This is needed becaused cl-defmethod doesn't exist in emacs24
-(cl-defun occ-build-capture-template-emacs-24-hack
+(cl-defmethod occ-build-capture-template
     (context &key (character "p") (heading "Category TODO"))
   (with-slots (template options strategy) context
     (apply 'list character heading 'entry
@@ -61,10 +60,7 @@
                  (apply-partially 'occ-get-capture-location strategy context))
            template options)))
 
-(defmethod occ-build-capture-template ((context occ-context) &rest args)
-  (apply 'occ-build-capture-template-emacs-24-hack context args))
-
-(defmethod occ-capture ((context occ-context))
+(cl-defmethod occ-capture ((context occ-context))
   (with-slots (category template options strategy)
       context
     (org-capture-set-plist (occ-build-capture-template context))
@@ -105,7 +101,7 @@
     (switch-to-buffer (marker-buffer marker))
     (goto-char (marker-position marker))))
 
-(defmethod occ-get-capture-marker ((context occ-context))
+(cl-defmethod occ-get-capture-marker ((context occ-context))
   (occ-get-capture-marker (oref context strategy) context))
 
 (cl-defun occ-get-category-heading-location

--- a/org-projectile.el
+++ b/org-projectile.el
@@ -172,31 +172,31 @@ compute this path."
 
 (defclass org-projectile-per-project-strategy nil nil)
 
-(defmethod occ-get-categories ((_ org-projectile-per-project-strategy))
+(cl-defmethod occ-get-categories ((_ org-projectile-per-project-strategy))
   (org-projectile-get-project-file-categories))
 
-(defmethod occ-get-todo-files ((_ org-projectile-per-project-strategy))
+(cl-defmethod occ-get-todo-files ((_ org-projectile-per-project-strategy))
   (mapcar 'org-projectile-get-project-todo-file projectile-known-projects))
 
-(defmethod occ-get-capture-file
+(cl-defmethod occ-get-capture-file
     ((s org-projectile-per-project-strategy) category)
   (let ((project-root
          (cdr (assoc category
                      (org-projectile-category-to-project-path s)))))
     (org-projectile-get-project-todo-file project-root)))
 
-(defmethod occ-get-capture-marker
+(cl-defmethod occ-get-capture-marker
     ((strategy org-projectile-per-project-strategy) context)
   (with-slots (category) context
     (let ((filepath (occ-get-capture-file strategy category)))
       (with-current-buffer (find-file-noselect filepath)
         (point-max-marker)))))
 
-(defmethod occ-target-entry-p
+(cl-defmethod occ-target-entry-p
     ((_ org-projectile-per-project-strategy) _context)
   nil)
 
-(defmethod org-projectile-category-to-project-path
+(cl-defmethod org-projectile-category-to-project-path
     ((_ org-projectile-per-project-strategy))
   (mapcar (lambda (path)
             (cons (org-projectile-category-from-project-root
@@ -220,16 +220,15 @@ compute this path."
 
 (defclass org-projectile-top-level-categories-specifier nil nil)
 
-(defmethod org-projectile-get-existing-categories
-  )
+(cl-defmethod org-projectile-get-existing-categories ())
 
 (defclass org-projectile-single-file-strategy nil nil)
 
-(defmethod org-projectile-category-to-project-path
+(cl-defmethod org-projectile-category-to-project-path
     ((_s org-projectile-single-file-strategy))
   (org-projectile-default-project-categories))
 
-(defmethod occ-get-categories
+(cl-defmethod occ-get-categories
     ((_s org-projectile-single-file-strategy))
   (cl-remove-if
    'null
@@ -238,7 +237,7 @@ compute this path."
      (org-projectile-get-categories-from-project-paths)
      (occ-get-categories-from-filepath org-projectile-projects-file)))))
 
-(defmethod occ-get-categories ((_s org-projectile-single-file-strategy))
+(cl-defmethod occ-get-categories ((_s org-projectile-single-file-strategy))
   (cl-remove-if
    'null
    (delete-dups
@@ -248,13 +247,13 @@ compute this path."
       org-projectile-projects-file
       :get-category-from-element 'org-projectile-get-category-from-heading)))))
 
-(defmethod occ-get-todo-files ((_ org-projectile-single-file-strategy))
+(cl-defmethod occ-get-todo-files ((_ org-projectile-single-file-strategy))
   (list org-projectile-projects-file))
 
-(defmethod occ-get-capture-file ((_ org-projectile-single-file-strategy) _c)
+(cl-defmethod occ-get-capture-file ((_ org-projectile-single-file-strategy) _c)
   org-projectile-projects-file)
 
-(defmethod occ-get-capture-marker
+(cl-defmethod occ-get-capture-marker
     ((strategy org-projectile-single-file-strategy) context)
   (with-slots (category) context
     (let ((filepath (occ-get-capture-file strategy category)))
@@ -269,10 +268,10 @@ compute this path."
 (defun org-projectile-linked-heading-regexp (heading)
   (format "\\[\\[.*?]\\[%s]]" heading))
 
-(defmethod occ-target-entry-p ((_ org-projectile-single-file-strategy) _c)
+(cl-defmethod occ-target-entry-p ((_ org-projectile-single-file-strategy) _c)
   t)
 
-(defmethod org-projectile-category-to-project-path
+(cl-defmethod org-projectile-category-to-project-path
     ((_ org-projectile-single-file-strategy))
   (mapcar (lambda (path)
             (cons (org-projectile-category-from-project-root

--- a/test/org-category-capture-test.el
+++ b/test/org-category-capture-test.el
@@ -50,12 +50,12 @@
 
 (defclass occ-test-strategy (occ-strategy) nil)
 
-(defmethod occ-get-capture-marker ((_ occ-test-strategy) context)
+(cl-defmethod occ-get-capture-marker ((_ occ-test-strategy) context)
   (with-slots (category) context
     (occ-goto-or-insert-category-heading category)
     (point-marker)))
 
-(defmethod occ-target-entry-p ((_ occ-test-strategy) context) t)
+(cl-defmethod occ-target-entry-p ((_ occ-test-strategy) context) t)
 
 (defvar occ-test-text-to-insert "dummy-text")
 


### PR DESCRIPTION
This PR removes emacs 24 support (which I think was dead anyhow as the CI had long dropped emacs 24).  It moves over to `cl-` and is thus emacs 29 compatible.

closes #52.

Note that tests pass (see my master branch) but I've based this on the current head in case my ci pr isn't accepted.